### PR TITLE
Fix gesture to open ShortenUrl dialog

### DIFF
--- a/addon/globalPlugins/urlShortener/__init__.py
+++ b/addon/globalPlugins/urlShortener/__init__.py
@@ -54,4 +54,4 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		description=_("Activates the Shorten URL dialog.")
 	)
 	def script_activateShortenUrlDialog(self, gesture):
-		wx.CallAfter(self.onFeeds, None)
+		wx.CallAfter(self.onShortenUrl, None)

--- a/addon/globalPlugins/urlShortener/skipTranslation.py
+++ b/addon/globalPlugins/urlShortener/skipTranslation.py
@@ -1,0 +1,10 @@
+# -*- coding: UTF-8 -*-
+# skipTranslation: Module to get translated texts from NVDA
+# Based on implementation made by Alberto Buffolino
+# https://github.com/nvaccess/nvda/issues/4652
+# Copyright (C) 2016 Noelia Ruiz Martínez
+# Released under GPL 2
+
+
+def translate(text):
+	return _(text)

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -14,6 +14,7 @@ import gui
 from gui import guiHelper
 
 from .isGd import IsGd, UrlMetadata
+from .skipTranslation import translate
 
 URLS_PATH = os.path.join(os.path.dirname(__file__), "urls.pickle")
 
@@ -100,7 +101,7 @@ class UrlsDialog(wx.Dialog):
 		sHelper.addItem(urlsListGroupSizer)
 
 		# Message translated in NVDA core.
-		closeButton = wx.Button(self, wx.ID_CLOSE, label=_("&Close"))
+		closeButton = wx.Button(self, wx.ID_CLOSE, label=translate("&Close"))
 		closeButton.Bind(wx.EVT_BUTTON, lambda evt: self.Close())
 		sHelper.addDialogDismissButtons(closeButton)
 		self.Bind(wx.EVT_CLOSE, self.onClose)
@@ -205,7 +206,7 @@ class UrlsDialog(wx.Dialog):
 			# Translators: The confirmation prompt displayed when the user requests to delete an URL.
 			_("Are you sure you want to delete this URL? This cannot be undone."),
 			# Message translated in NVDA core.
-			_("Confirm Deletion"),
+			translate("Confirm Deletion"),
 			wx.YES | wx.NO | wx.ICON_QUESTION, self
 		) == wx.NO:
 			self.urlsList.SetFocus()


### PR DESCRIPTION
## Link to issue number:
None.
Reported by Danilo Loques on the add-ons mailing list:
https://nvda-addons.groups.io/g/nvda-addons/message/21203
### Summary of the issue:
The gesture to open Shorten URL dialog doesn't work due to a badcopy-paste.
### Description of how this pull request fixes the issue:
Replace onFeeds with onShortenUrl in the script corresponding to the command for the add-on dialog.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None