### PR TITLE
Quote URLs and don't sort them until next dialog activation

### DIFF
--- a/addon/globalPlugins/urlShortener/isGd.py
+++ b/addon/globalPlugins/urlShortener/isGd.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from urllib.request import urlopen, Request
-from urllib.parse import unquote
+from urllib.parse import quote
 from typing import Optional
 
 from logHandler import log
@@ -35,11 +35,11 @@ class IsGd(UrlShortener):
 
 	def shortenUrl(self) -> Optional[str]:
 		url = self.originalUrl
-		unquotedUrl = unquote(url)
+		quotedUrl = quote(url)
 		headers = {
 			'User-Agent': 'Mozilla'
 		}
-		apiUrl = f"https://is.gd/create.php?format=simple&url={unquotedUrl}"
+		apiUrl = f"https://is.gd/create.php?format=simple&url={quotedUrl}"
 		try:
 			resp = urlopen(Request(apiUrl, headers=headers))
 			self.shortenedUrl = resp.read().decode("utf-8")

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -40,6 +40,7 @@ class UrlsDialog(wx.Dialog):
 		try:
 			with open(URLS_PATH, "rb") as f:
 				self._urls = pickle.load(f)
+			self._urls.sort(key=getUrlMetadataName)
 		except Exception:
 			self._urls = [UrlMetadata("example.com", "example.com", "https://is.gd/iKpnPV")]
 
@@ -186,7 +187,6 @@ class UrlsDialog(wx.Dialog):
 			return
 		urlMetadata = self.shortenUrl(d.Value)
 		self._urls.append(urlMetadata)
-		self._urls.sort(key=getUrlMetadataName)
 		try:
 			with open(URLS_PATH, "wb") as f:
 				pickle.dump(self._urls, f, protocol=0)


### PR DESCRIPTION
## Link to issue number:
None. Bug reported by Danilo Loques on the add-ons mailing list:
https://nvda-addons.groups.io/g/nvda-addons/message/21219
### Summary of the issue:
URLS containing %20 aren't shortened. According to documentation, URLs should be quoted (not unquoted):
Here's [is.gd API reference](https://is.gd/apishorteningreference.php)

### Description of how this pull request fixes the issue:
- Use quote instead of unquote for URLs.
- Additionaly, as aside, don't sort URLs when saving, so that the last item in the list when creating an URLs is properly addressed to copy the sortened URL. Instead, sort them when dialog is opened.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None