### PR TITLE
Use installTasks to add and remove addon config path

### DIFF
--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -19,8 +19,9 @@ from gui import guiHelper
 
 from .isGd import IsGd, UrlMetadata
 from .skipTranslation import translate
+from ...installTasks import ADDON_CONFIG_PATH
 
-URLS_PATH = os.path.join(os.path.dirname(__file__), "urls.json")
+URLS_PATH = os.path.join(ADDON_CONFIG_PATH, "URLS.JSON")
 
 
 def getUrlMetadataName(urlMetadata):

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -5,8 +5,8 @@
 # Released under GPL2
 
 import os
+import shutil
 
-import addonHandler
 import globalVars
 
 CONFIG_PATH = globalVars.appArgs.configPath
@@ -19,7 +19,4 @@ def onInstall():
 
 
 def onUninstall():
-	try:
-		os.removedirs(ADDON_CONFIG_PATH)
-	except Exception as e:
-		raise e
+	shutil.rmtree(ADDON_CONFIG_PATH, ignore_errors=True)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -4,27 +4,22 @@
 # Copyright (C) 2023 Noelia Ruiz Martínez, other contributors
 # Released under GPL2
 
-import json
 import os
 
 import addonHandler
 import globalVars
 
-ADDON_DIR = os.path.abspath(os.path.dirname(__file__))
-URLS_PATH = os.path.join(ADDON_DIR, "globalPlugins", "urlShortener")
 CONFIG_PATH = globalVars.appArgs.configPath
-
-addonHandler.initTranslation()
+ADDON_CONFIG_PATH = os.path.join(CONFIG_PATH, "urlShortener")
 
 
 def onInstall():
-	previousUrlsPath = os.path.join(
-		CONFIG_PATH, "addons", "urlShortener",
-		"globalPlugins", "urlShortener", "urls.json"
-	)
-	if not os.path.isfile(previousUrlsPath):
-		return
-	with open(previousUrlsPath, "rt") as f:
-		data = json.load(f)
-	with open(URLS_PATH, "wt") as f:
-		json.dump(data, f, indent="\t")
+	if not os.path.isdir(ADDON_CONFIG_PATH):
+		os.makedirs(ADDON_CONFIG_PATH)
+
+
+def onUninstall():
+	try:
+		os.removedirs(ADDON_CONFIG_PATH)
+	except Exception as e:
+		raise e


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Trying to save json files to store data copying from previous path at installation doesn't always work.
### Description of how this pull request fixes the issue:
Use onInstall function of installTasks to create a folder for this add-on in the config path, and remove it when the add-on is uninstalled.
### Testing performed:
None
### Known issues with pull request:
None
### Change log entry:
None