### PR TITLE
Replace the URL  dialog with a set of controls in the main dialog for a better handling of errors

### DIFF
--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -167,8 +167,10 @@ class UrlsDialog(wx.Dialog):
 			self.customUrlTextCtrl.SetFocus()
 			return
 		if customUrl and (len(customUrl) < 5 or len(customUrl) > 30):
-			# Translators: Message presented when a custom URL has a wrong length.
-			core.callLater(100, ui.message, _("This custom URL has %d characters. Length must be between 5 and 30.") % len(customUrl))
+			core.callLater(
+				# Translators: Message presented when a custom URL has a wrong length.
+				100, ui.message, _("This custom URL has %d characters. Length must be between 5 and 30.") % len(customUrl)
+			)
 			self.customUrlTextCtrl.SetFocus()
 			return
 		try:

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -163,7 +163,7 @@ class UrlsDialog(wx.Dialog):
 			return
 		if customUrl in customUrls:
 			# Translators: Message presented when a custom URL is already saved.
-			core.callLater(100, ui.message, _("This custom URL was already used: %s. Please try with a different subfix.") % customUrl)
+			core.callLater(100, ui.message, _("This custom URL was already used. Try with a different subfix."))
 			self.customUrlTextCtrl.SetFocus()
 			return
 		if customUrl and (len(customUrl) < 5 or len(customUrl) > 30):
@@ -176,7 +176,7 @@ class UrlsDialog(wx.Dialog):
 			if not url:
 				if customUrl:
 					# Translators: Message presented when a custom URL cannot be added.
-					core.callLater(100, ui.message, _("This custom URL is not available. Please try with a different subfix."))
+					core.callLater(100, ui.message, _("This custom URL is not available. Try with a different subfix."))
 					self.customUrlTextCtrl.SetFocus()
 				else:
 					# Translators: Message presented when an URL cannot be shortened.

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ The Shorten URL dialog includes the following controls:
 * Remove saved URLs: opens a dialog to remove the saved URLs from the configuration folder.
 * Close.
 
-## Changes for 4.0.0 ##
+## Changes for 5.0.0 ##
 
 * The new URL dialog has been replaced with a set of controls in the main dialog, so that the focus can be placed in the relevant field to fix possible errors.
 

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,15 @@ The Shorten URL dialog includes the following controls:
 
 * A list to select one of the saved URLs. From this list, Press shift+tab to search, and tab to press one of the following buttons.
 * Copy shortened URL. This can also be activated by pressing Enter from the URLs list.
-* New: opens a dialog to type an URL to be shortened. A display name and a custom subfix for the shortened URL maybe provided from this dialog.
+* Set of controls to shorten a new URL: Provide the new URL; optionally, you can set a display name and a custom subfix for the shortened URL. Finally, press the Shorten URL button.
 * Rename: opens a dialog to provide a new name to display the selected URL on the list.
 * Delete: opens a dialog to delete the selected URL.
 * Remove saved URLs: opens a dialog to remove the saved URLs from the configuration folder.
 * Close.
+
+## Changes for 4.0.0 ##
+
+* The new URL dialog has been replaced with a set of controls in the main dialog, so that the focus can be placed in the relevant field to fix possible errors.
 
 ## Changes for 2.0.0 ##
 


### PR DESCRIPTION
## Link to issue number:
Fixes issue #10
### Summary of the issue:
When an URL cannot be created, the reason is not notified to the user.
### Description of how this pull request fixes the issue:
* The NEW URL modal dialog is replaced with controls to provide the new URL, name, custom URL and a buttom to shorten.
* When known errors can be fixed, the focus should be placed in the corresponding input field.
* If an exception is raised, an error dialog should be presented showing the error, though I have never reproduced it.
### Testing performed:
Tested locally with different custom URLS,with and without a display name, and unplugging wifi.
### Known issues with pull request:
None.
### Change log entry:
* The new URL dialog has been replaced with a set of controls in the main dialog, so that the focus can be placed in the relevant field to fix possible errors.