### PR TITLE
Add a readonly edit box with details about the selected URL

### DIFF
--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -245,6 +245,7 @@ class UrlsDialog(wx.Dialog):
 		self.sel = self.urlsList.Selection
 		self.stringSel = self.urlsList.GetString(self.sel)
 		url = self._urls[self.filteredItems[self.sel]]
+		# Translators: Info about the selected URL.
 		urlInfo = _(
 			"Original URL: {}\n"
 			# Translators: Info about the selected URL.

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -18,7 +18,7 @@ import globalVars
 import ui
 from logHandler import log
 import gui
-from gui import guiHelper
+from gui import guiHelper, messageBox
 
 from .isGd import IsGd, UrlMetadata
 from .skipTranslation import translate
@@ -99,6 +99,14 @@ class UrlsDialog(wx.Dialog):
 		self.AffirmativeId = self.copyButton.Id
 		self.copyButton.SetDefault()
 		self.copyButton.Bind(wx.EVT_BUTTON, self.onCopy)
+
+		# Translators: The label of an edit box to show more details about the selected URL.
+		detailsLabel = _("Deta&ils:")
+		detailsLabeledCtrl = gui.guiHelper.LabeledControlHelper(
+			self, detailsLabel, wx.TextCtrl,
+			style=wx.TE_MULTILINE | wx.TE_READONLY
+		)
+		self.detailsEdit = detailsLabeledCtrl.control
 
 		# Translators: The label of a field to enter an address for a new shortened URL.
 		urlLabelText = _("New &URL")
@@ -236,6 +244,15 @@ class UrlsDialog(wx.Dialog):
 		self.urlsList.Enable()
 		self.sel = self.urlsList.Selection
 		self.stringSel = self.urlsList.GetString(self.sel)
+		url = self._urls[self.filteredItems[self.sel]]
+		urlInfo = _(
+			"Original URL: {}\n"
+			"Name: {}\n"
+			"Shortened URL: {}".format(
+				url.originalUrl, url.name, url.shortenedUrl
+			)
+		)
+		self.detailsEdit.Value = urlInfo
 		self.renameButton.Enabled = self.sel >= 0
 		self.deleteButton.Enabled = (self.sel >= 0 and self.urlsList.Count > 1)
 		self.removeSettingsButton.Enabled = os.path.isdir(ADDON_CONFIG_PATH)

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -18,7 +18,7 @@ import globalVars
 import ui
 from logHandler import log
 import gui
-from gui import guiHelper
+from gui import guiHelper, messageBox
 
 from .isGd import IsGd, UrlMetadata
 from .skipTranslation import translate
@@ -104,7 +104,7 @@ class UrlsDialog(wx.Dialog):
 		detailsLabel = _("Deta&ils:")
 		detailsLabeledCtrl = gui.guiHelper.LabeledControlHelper(
 			self, detailsLabel, wx.TextCtrl,
-			style=wx.TE_MULTILINE | wx.TE_READONLY
+			style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_DONTWRAP
 		)
 		self.detailsEdit = detailsLabeledCtrl.control
 
@@ -246,7 +246,6 @@ class UrlsDialog(wx.Dialog):
 		self.stringSel = self.urlsList.GetString(self.sel)
 		url = self._urls[self.filteredItems[self.sel]]
 		urlInfo = _(
-			# Translators: Details about the selected URL.
 			"Original URL: {}\n"
 			"Name: {}\n"
 			"Shortened URL: {}".format(

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -245,10 +245,9 @@ class UrlsDialog(wx.Dialog):
 		self.sel = self.urlsList.Selection
 		self.stringSel = self.urlsList.GetString(self.sel)
 		url = self._urls[self.filteredItems[self.sel]]
-		# Translators: Info about the selected URL.
 		urlInfo = _(
-			"Original URL: {}\n"
 			# Translators: Info about the selected URL.
+			"Original URL: {}\n"
 			"Name: {}\n"
 			"Shortened URL: {}".format(
 				url.originalUrl, url.name, url.shortenedUrl

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -246,6 +246,7 @@ class UrlsDialog(wx.Dialog):
 		self.stringSel = self.urlsList.GetString(self.sel)
 		url = self._urls[self.filteredItems[self.sel]]
 		urlInfo = _(
+			# Translators: Details about the selected URL.
 			"Original URL: {}\n"
 			"Name: {}\n"
 			"Shortened URL: {}".format(

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -18,7 +18,7 @@ import globalVars
 import ui
 from logHandler import log
 import gui
-from gui import guiHelper, messageBox
+from gui import guiHelper
 
 from .isGd import IsGd, UrlMetadata
 from .skipTranslation import translate
@@ -247,6 +247,7 @@ class UrlsDialog(wx.Dialog):
 		url = self._urls[self.filteredItems[self.sel]]
 		urlInfo = _(
 			"Original URL: {}\n"
+			# Translators: Info about the selected URL.
 			"Name: {}\n"
 			"Shortened URL: {}".format(
 				url.originalUrl, url.name, url.shortenedUrl

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -18,7 +18,7 @@ import globalVars
 import ui
 from logHandler import log
 import gui
-from gui import guiHelper, messageBox
+from gui import guiHelper
 
 from .isGd import IsGd, UrlMetadata
 from .skipTranslation import translate

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,16 @@ The Shorten URL dialog includes the following controls:
 
 * A list to select one of the saved URLs. From this list, Press shift+tab to search, and tab to press one of the following buttons.
 * Copy shortened URL. This can also be activated by pressing Enter from the URLs list.
+* A readonly box showing details about the selected URL.
 * Set of controls to shorten a new URL: Provide the new URL; optionally, you can set a display name and a custom subfix for the shortened URL. Finally, press the Shorten URL button.
 * Rename: opens a dialog to provide a new name to display the selected URL on the list.
 * Delete: opens a dialog to delete the selected URL.
 * Remove saved URLs: opens a dialog to remove the saved URLs from the configuration folder.
 * Close.
+
+## Changes for 8.0.0 ##
+
+* Added a readonly box with details about the selected URL.
 
 ## Changes for 5.0.0 ##
 


### PR DESCRIPTION

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixesissue #14
### Summary of the issue:
Details like the original URL aren't presented in the URLs dialog.
### Description of how this pull request fixes the issue:
Added a multiline readonly edit box to show more info about the selected URL.
### Testing performed:
Tested locally.
### Known issues with pull request:
The shortened URL is presented by NVDA in two lines when arrow keys are used.
### Change log entry:
* Added a readonly edit box to see detailed info about the selected URL.