### PR TITLE
Compatibility with NVDA 2024.1

### DIFF
--- a/addon/globalPlugins/urlShortener/__init__.py
+++ b/addon/globalPlugins/urlShortener/__init__.py
@@ -31,7 +31,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	scriptCategory = ADDON_SUMMARY
 
 	def __init__(self):
-		super(GlobalPlugin, self).__init__()
+		super().__init__()
 		self.toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
 		# Translators: the name of a menu item.
 		self.urlsListItem = self.toolsMenu.Append(wx.ID_ANY, _("&Shorten URL..."))

--- a/addon/globalPlugins/urlShortener/urlsGui.py
+++ b/addon/globalPlugins/urlShortener/urlsGui.py
@@ -59,7 +59,7 @@ class UrlsDialog(wx.Dialog):
 		except Exception as e:
 			self._urls = [UrlMetadata("example.com", "example.com", "https://is.gd/iKpnPV")]
 			log.debugWarning(f"Could not open URLs file: {e}")
-		super(UrlsDialog, self).__init__(
+		super().__init__(
 			# Translators: The title of a dialog.
 			parent, title=_("urls")
 		)
@@ -87,7 +87,7 @@ class UrlsDialog(wx.Dialog):
 		self.urlsList.Selection = 0
 		self.urlsList.Bind(wx.EVT_LISTBOX, self.onUrlsListChoice)
 
-		changeUrlsSizer.Add(self.urlsList, proportion=1.0)
+		changeUrlsSizer.Add(self.urlsList, proportion=1)
 		changeUrlsSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICAL)
 		urlsListGroupContents.Add(changeUrlsSizer, flag=wx.EXPAND)
 		urlsListGroupContents.AddSpacer(guiHelper.SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2023.1.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1.0",
+	"addon_lastTestedNVDAVersion": "2024.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 will be an API breaking change release, so that add-ons need to be retested.
### Description of how this pull request fixes the issue:
Change proportion=1.0 to proportion=1.
Also, calls to super() method has been simplified.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None.